### PR TITLE
Fix memory leak in IPv4 path of IP2Proxy_get_record

### DIFF
--- a/libIP2Proxy/IP2Proxy.c
+++ b/libIP2Proxy/IP2Proxy.c
@@ -623,7 +623,7 @@ static IP2ProxyRecord *IP2Proxy_get_record(IP2Proxy *handler, char *ip, uint32_t
 			return IP2Proxy_bad_record(NOT_SUPPORTED);
 		}
 
-		return IP2Proxy_get_ipv4_record(handler, mode, parsed_ip);
+		return record;
 	}
 	if (parsed_ip.version == 6) {
 		if (handler->ipv6_database_count == 0) {


### PR DESCRIPTION
This patch fixes a memory leak in the IPv4 branch of `IP2Proxy_get_record`.

Previously, the function called `IP2Proxy_get_ipv4_record()` twice:

```c
record = IP2Proxy_get_ipv4_record(handler, mode, parsed_ip);
if (record == NULL) {
    return IP2Proxy_bad_record(NOT_SUPPORTED);
}
return IP2Proxy_get_ipv4_record(handler, mode, parsed_ip);
```

The first allocated record was lost without being freed, causing a per-request
memory leak whenever an IPv4 address was processed.

The fix ensures that the already allocated record is returned instead of
calling the function again:
```c
record = IP2Proxy_get_ipv4_record(handler, mode, parsed_ip);
if (record == NULL) {
    return IP2Proxy_bad_record(NOT_SUPPORTED);
}
return record;
```
This eliminates the per-request memory leak for IPv4 lookups.